### PR TITLE
join `pathname` and `search` with '' not '?'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ function bindUrl ({wnd, root}, cb) {
 
   function update () {
     const {pathname, search} = wnd.location
-    cb([pathname, search].filter(Boolean).join('?'))
+    cb([pathname, search].filter(Boolean).join(''))
   }
 
   function pushState (url) {


### PR DESCRIPTION
`search` already starts with a '?', so joining by '?' actually breaks the URL.

per [`Location` documentation](https://developer.mozilla.org/en-US/docs/Web/API/Location):

> `search` is a DOMString containing a '?' followed by the parameters of the URL.
